### PR TITLE
Zero parameter functions should be declared with "void"

### DIFF
--- a/src/Plover/Print.hs
+++ b/src/Plover/Print.hs
@@ -72,15 +72,23 @@ ppLine strict off (LineDecl t var) =
   off ++ pre ++ " " ++ ppVar var ++ post ++ lineEnd
 ppLine strict off (Function name (FnT ps1 ps2 out) body) =
   off ++ ppType out ++ " " ++ name ++
-    wrapp (intercalate ", " (map (ppParam strict) (ps1 ++ ps2))) ++ "\n" ++
+    wrapp argString ++ "\n" ++
   off ++ "{\n" ++
     ppLine strict (indent off) body ++
   off ++ "}\n"
+  where args = map (ppParam strict) (ps1 ++ ps2)
+        argString = case args of
+          [] -> "void"
+          as -> intercalate ", " $ map (ppParam strict) (ps1 ++ ps2)
 ppLine strict off (LineReturn x) =
   off ++ "return " ++ ppExpr strict x ++ lineEnd
 ppLine strict off (ForwardDecl name (FnT ps1 ps2 out)) =
   off ++ ppType out ++ " " ++ name ++
-    wrapp (intercalate ", " (map (ppParam strict) (ps1 ++ ps2))) ++ lineEnd
+    wrapp argString ++ lineEnd
+  where args = map (ppParam strict) (ps1 ++ ps2)
+        argString = case args of
+          [] -> "void"
+          as -> intercalate ", " $ map (ppParam strict) (ps1 ++ ps2)
 ppLine strict off (TypeDefStruct name fields) =
   off ++ "typedef struct {\n" ++
     concatMap printField fields ++


### PR DESCRIPTION
`void foo()` is not a valid function prototype.

should be `void foo(void)`

See C99 std (ISO 9989) pg. 6.7.5.3 # 10, 14:
http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf
